### PR TITLE
feature/#73 : 주문취소 및 반품처리

### DIFF
--- a/src/main/java/shop/wannab/frontservice/global/config/WebConfig.java
+++ b/src/main/java/shop/wannab/frontservice/global/config/WebConfig.java
@@ -23,8 +23,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addViewController("/user/main-book-detail").setViewName("user/main-book-detail");
         registry.addViewController("/user/main-cart").setViewName("user/main-cart");
         registry.addViewController("/user/main-order").setViewName("user/main-order");
-        registry.addViewController("/user/main-non-member-order").setViewName("user/main-non-member-order");
-        registry.addViewController("/user/main-non-member-order-detail").setViewName("user/order-detail");
+        registry.addViewController("/guest/main-non-member-order").setViewName("guest/main-non-member-order");
+        registry.addViewController("/guest/main-non-member-order-detail").setViewName("user/order-detail");
 
     }
 

--- a/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
+++ b/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
@@ -3,11 +3,13 @@ package shop.wannab.frontservice.order.client;
 import jakarta.servlet.http.Cookie;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shop.wannab.frontservice.order.list.deliveryPolicy.dto.DeliveryPolicyRequest;
 import shop.wannab.frontservice.order.list.deliveryPolicy.dto.DeliveryPolicyResponse;
 import shop.wannab.frontservice.order.dto.*;
 import shop.wannab.frontservice.order.list.orderDetail.dto.OrderDetailResponse;
+import shop.wannab.frontservice.order.list.orderDetail.dto.RefundReason;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderLookupResponse;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderStatus;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.PageResponse;
@@ -102,6 +104,35 @@ public interface OrderApiClient {
     @GetMapping("/api/orders")
     PageResponse<OrderLookupResponse> getOrdersByUser(@RequestParam int page,
                                                     @RequestParam int size);
+
+
+    /**
+     * 회원 주문취소
+     */
+    @PostMapping("/api/orders/{orderId}/cancel")
+    public ResponseEntity<Void> cancelOrder(@PathVariable Long orderId);
+
+    /**
+     * 회원 반품
+     */
+    @PostMapping("/api/orders/{orderId}/refund")
+    public ResponseEntity<Void> refundOrder(@PathVariable Long orderId,
+                                            @RequestParam RefundReason reason);
+
+    /**
+     * 비회원 주문취소
+     */
+    @PostMapping("/api/orders/guest/cancel")
+    public ResponseEntity<Void> cancelGuestOrder(@RequestParam Long orderId,
+                                                 @RequestParam String password);
+
+    /**
+     * 비회원 반품
+     */
+    @PostMapping("/api/orders/guest/refund")
+    public ResponseEntity<Void> refundGuestOrder(@RequestParam Long orderId,
+                                                 @RequestParam String password,
+                                                 @RequestParam RefundReason reason);
 
 
     /**

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/OrderDetailController.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/OrderDetailController.java
@@ -2,12 +2,17 @@ package shop.wannab.frontservice.order.list.orderDetail;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import shop.wannab.frontservice.order.client.OrderApiClient;
 import shop.wannab.frontservice.order.list.orderDetail.dto.OrderDetailResponse;
+import shop.wannab.frontservice.order.list.orderDetail.dto.RefundReason;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderLookupResponse;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.PageResponse;
 import shop.wannab.frontservice.user.dto.UserPageResponse;
@@ -22,15 +27,17 @@ public class OrderDetailController {
     private final UserService userService;
 
 
+    //TODO : 비밀번호 url에 표시안되게 수정하기
     /**
      비회원 주문상세조회
      */
-    @GetMapping("/user/main-non-member-order-detail")
+    @GetMapping("/guest/main-non-member-order-detail")
     public String getGuestOrderPage(@RequestParam Long orderId,
                                     @RequestParam String password,
                                     Model model){
         OrderDetailResponse order = orderApiClient.getGuestOrderDetail(orderId, password);
         model.addAttribute("order", order);
+        model.addAttribute("isGuest", true);
         return "user/order-detail";
     }
 
@@ -41,6 +48,7 @@ public class OrderDetailController {
                                    Model model){
         OrderDetailResponse order = orderApiClient.getOrderDetail(orderId);
         model.addAttribute("order", order);
+        model.addAttribute("isGuest", false);
         return "user/order-detail";
     }
 
@@ -69,5 +77,66 @@ public class OrderDetailController {
 
         return "user/mypage-order";
     }
+
+
+    /**
+     * 회원 주문취소
+     */
+    @PostMapping("user/mypage-order/cancel")
+    public String userOrderCancel(@RequestParam Long orderId,
+                                  RedirectAttributes redirectAttributes){
+
+        orderApiClient.cancelOrder(orderId);
+        redirectAttributes.addFlashAttribute("message", "주문취소요청이 처리되었습니다.");
+
+        return "redirect:/user/mypage-order";
+    }
+
+    /**
+     * 회원 반품
+     */
+    @PostMapping("user/mypage-order/refund")
+    public String userOrderRefund(@RequestParam Long orderId,
+                                  @RequestParam String reason,
+                                  RedirectAttributes redirectAttributes){
+
+        RefundReason refundReason = RefundReason.valueOf(reason);
+        orderApiClient.refundOrder(orderId, refundReason);
+        redirectAttributes.addFlashAttribute("message", "주문반품요청이 처리되었습니다.");
+
+        return "redirect:/user/mypage-order";
+    }
+
+    //TODO : 비밀번호 url에 표시안되게 수정하기
+    /**
+     * 비회원 주문취소
+     */
+    @PostMapping("/guest/main-non-member-order-detail/cancel")
+    public String guestOrderCancel(@RequestParam Long orderNumber,
+                                   @RequestParam String password,
+                                   RedirectAttributes redirectAttributes){
+        orderApiClient.cancelGuestOrder(orderNumber, password);
+        redirectAttributes.addFlashAttribute("message", "주문취소요청이 처리되었습니다.");
+
+        return "redirect:/guest/main-non-member-order-detail?orderId=" + orderNumber + "&password=" + password;
+    }
+
+    /**
+     * 비회원 반품
+     */
+    @PostMapping("/guest/main-non-member-order-detail/refund")
+    public String guestOrderRefund(@RequestParam Long orderNumber,
+                                   @RequestParam String password,
+                                   @RequestParam String reason,
+                                   RedirectAttributes redirectAttributes){
+        RefundReason refundReason = RefundReason.valueOf(reason);
+        orderApiClient.refundGuestOrder(orderNumber, password, refundReason);
+
+        redirectAttributes.addFlashAttribute("message", "주문반품요청이 처리되었습니다.");
+
+        return "redirect:/guest/main-non-member-order-detail?orderId=" + orderNumber + "&password=" + password;
+    }
+
+
 
 }

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderBookDetailResponse.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderBookDetailResponse.java
@@ -2,21 +2,23 @@ package shop.wannab.frontservice.order.list.orderDetail.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 주문 상세 페이지에서 보여줄 도서에 대한 정보를 담는 dto
  */
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderBookDetailResponse {
-    private final Long bookId;
-    private final String title;
-    private final int quantity;
+    private Long bookId;
+    private String title;
+    private int quantity;
 
     /**
      * 도서마다 총가격
      * (도서개당가격 * quantity)
      */
-    private final int bookTotalPrice;
-    private final String thumbnailUrl;
+    private int bookTotalPrice;
+    private String thumbnailUrl;
 }

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderDetailResponse.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderDetailResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderStatus;
 
 /**
@@ -11,33 +12,29 @@ import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderStatus;
  */
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class OrderDetailResponse {
 
-    private final List<OrderBookDetailResponse> books;
+    private List<OrderBookDetailResponse> books;
 
     /**
      * 주문 번호
      * (일단 order ID 사용)
      */
-    private final Long orderNumber;
+    private Long orderNumber;
 
     /**
      * 주문 일시
      */
-    private final LocalDateTime orderAt;
-
-    /**
-     * 결제 일시
-     */
-    private final LocalDateTime paymentAt;
+    private LocalDateTime orderAt;
 
     /**
      * 주문 상태
      */
-    private final OrderStatus orderStatus;
+    private OrderStatus orderStatus;
 
     /**
      * 총 주문 금액
      */
-    private final int totalPrice;
+    private int totalPrice;
 }

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/RefundReason.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/RefundReason.java
@@ -1,0 +1,6 @@
+package shop.wannab.frontservice.order.list.orderDetail.dto;
+
+public enum RefundReason {
+    JUST, //단순변심
+    DAMAGED //파손
+}

--- a/src/main/resources/templates/components/header.html
+++ b/src/main/resources/templates/components/header.html
@@ -4,7 +4,7 @@
     <span th:onclick="|window.location.href='@{/user/main-cart}'|">🛒</span>
     <!--회원 비회원 분기처리 필요-->
     <span th:onclick="|window.location.href='@{/user/mypage}'|">👤</span>
-    <span th:onclick="|window.location.href='@{/user/main-non-member-order}'|">📋</span>
+    <span th:onclick="|window.location.href='@{/guest/main-non-member-order}'|">📋</span>
 
     <span th:onclick="|window.location.href='@{/auth/logout}'|">🔓</span>
   </div>

--- a/src/main/resources/templates/guest/main-non-member-order.html
+++ b/src/main/resources/templates/guest/main-non-member-order.html
@@ -18,7 +18,7 @@
         <div class="non-member-order-box">
             <h2 class="non-member-order-title">비회원 주문 조회</h2>
 
-            <form class="non-member-order-form" method="get" action="/user/main-non-member-order-detail">
+            <form class="non-member-order-form" method="get" action="/guest/main-non-member-order-detail">
                 <label for="orderId">Order Id</label>
                 <input type="text" id="orderId" name="orderId" placeholder="주문번호를 입력하세요" required />
 

--- a/src/main/resources/templates/user/mypage-order.html
+++ b/src/main/resources/templates/user/mypage-order.html
@@ -45,12 +45,44 @@
         <p>
           <a th:href="@{/user/mypage-order-detail(orderId=${order.orderId})}" class="detail">상세 보기</a>
           <span class="review" onclick="openModal('review-modal')">리뷰 작성</span>
-          <span class="return">반품</span>
-          <span class="cancel">주문 취소</span>
+          <span class="return text-xs text-yellow-600 cursor-pointer"
+                th:if="${order.orderStatus.name() == 'COMPLETED'}"
+                th:attr="data-order-id=${order.orderId}"
+                onclick="openRefundModal(this)">반품
+          </span>
+          <span class="cancel text-xs text-red-500 cursor-pointer"
+                th:if="${order.orderStatus.name() == 'PENDING'}"
+                th:attr="data-order-id=${order.orderId}"
+                onclick="submitCancel(this)">
+              주문 취소
+          </span>
         </p>
       </div>
     </div>
   </section>
+</div>
+
+<!--주문취소-->
+<form id="cancel-form" method="post" th:action="@{/user/mypage-order/cancel}">
+  <input type="hidden" name="orderId" id="cancel-order-id" />
+</form>
+
+<!--반품모달-->
+<div class="modal-overlay" id="refund-modal" style="display: none;">
+  <div class="modal-content">
+    <span class="modal-close" onclick="closeModal('refund-modal')">&times;</span>
+    <h2>반품 요청</h2>
+    <form method="post" th:action="@{/user/mypage-order/refund}">
+      <input type="hidden" name="orderId" id="refund-order-id" />
+      <label>반품 사유 선택</label>
+      <select name="reason" required>
+        <option value="">선택하세요</option>
+        <option value="JUST">단순변심</option>
+        <option value="DAMAGED">상품파손</option>
+      </select><br /><br />
+      <button type="submit" class="btn-submit">반품 요청</button>
+    </form>
+  </div>
 </div>
 
 <!-- 주문 상세 모달 -->
@@ -122,7 +154,36 @@
 
 </div>
 
+
+<script>
+  // 반품 모달 열기
+  function openRefundModal(el) {
+    const orderId = el.getAttribute('data-order-id');
+    document.getElementById('refund-order-id').value = orderId;
+    document.getElementById('refund-modal').style.display = 'block';
+  }
+
+  // 리뷰 모달 열기 (기존 사용중인 함수)
+  function openModal(id) {
+    document.getElementById(id).style.display = 'block';
+  }
+
+  // 모달 닫기
+  function closeModal(id) {
+    document.getElementById(id).style.display = 'none';
+  }
+
+  //취소에 대한 orderId 받기
+  function submitCancel(el) {
+    const orderId = el.getAttribute('data-order-id');
+    document.getElementById('cancel-order-id').value = orderId;
+    document.getElementById('cancel-form').submit();
+  }
+</script>
+
 </body>
+
+
 
 </html>
 

--- a/src/main/resources/templates/user/order-detail.html
+++ b/src/main/resources/templates/user/order-detail.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       th:replace="~{layout/user-layout :: layout (
-      '비회원 주문 상세 페이지',
+      '주문 상세 페이지',
       ~{::body},
       ~{::head}
     )}">
@@ -26,25 +26,44 @@
                 <p class="font-medium" th:text="${#temporals.format(order.orderAt, 'yyyy-MM-dd HH:mm')}"></p>
             </div>
             <div>
-                <p class="text-gray-500">결제일시</p>
-                <p class="font-medium" th:text="${#temporals.format(order.paymentAt, 'yyyy-MM-dd HH:mm')}"></p>
-            </div>
-            <div>
                 <p class="text-gray-500 font-semibold mb-1">상태</p>
-                <p th:switch="${order.orderStatus.name()}" class="font-medium">
-                    <span th:case="'PENDING'" class="text-gray-500">대기</span>
-                    <span th:case="'SHIPPING'" class="text-green-500">배송중</span>
-                    <span th:case="'COMPLETED'" class="text-black">배송 완료</span>
-                    <span th:case="'RETURNED'" class="text-red-500">반품</span>
-                    <span th:case="'CANCELLED'" class="text-orange-500">주문취소</span>
-                    <span th:case="*" class="text-yellow-500">알 수 없음</span>
-                </p>
+                <div class="flex items-center gap-3">
+                    <p th:switch="${order.orderStatus.name()}" class="font-medium">
+                        <span th:case="'PENDING'" class="text-gray-500">대기</span>
+                        <span th:case="'SHIPPING'" class="text-green-500">배송중</span>
+                        <span th:case="'COMPLETED'" class="text-black">배송 완료</span>
+                        <span th:case="'RETURNED'" class="text-red-500">반품</span>
+                        <span th:case="'CANCELLED'" class="text-orange-500">주문취소</span>
+                        <span th:case="*" class="text-yellow-500">알 수 없음</span>
+                    </p>
+
+                    <!-- 비회원일시 버튼 보여주기 -->
+                    <button
+                            type="button"
+                            th:if="${isGuest and order.orderStatus.name() == 'PENDING'}"
+                            th:attr="data-order-number=${order.orderNumber}"
+                            class="text-xs px-2 py-1 bg-red-500 hover:bg-red-600 text-white rounded-md"
+                            onclick="openPasswordModal(this)">
+                        주문 취소
+                    </button>
+
+                    <button
+                        type="button"
+                        th:if="${isGuest and order.orderStatus.name() == 'COMPLETED'}"
+                        th:attr="data-order-number=${order.orderNumber}"
+                        class="text-xs px-2 py-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded-md"
+                        onclick="openRefundModal(this)">
+                        반품 요청
+                    </button>
+                </div>
             </div>
+
             <div>
                 <p class="text-gray-500">총 주문 금액</p>
                 <p class="font-medium text-rose-600" th:text="${#numbers.formatInteger(order.totalPrice, 3, 'COMMA')} + '원'">12,000원</p>
             </div>
         </div>
+
     </section>
 
     <!-- 도서 리스트 -->
@@ -65,6 +84,102 @@
         </div>
     </section>
 </div>
+
+<!-- 주문 취소용 비밀번호 입력 모달 -->
+<div id="passwordModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden z-50">
+    <div class="bg-white rounded-xl p-6 w-full max-w-sm shadow-lg">
+        <h3 class="text-lg font-semibold mb-4">비밀번호 확인</h3>
+        <form id="guestCancelForm" method="post" action="">
+            <input type="password" name="password" placeholder="비밀번호 입력"
+                   class="w-full px-3 py-2 border rounded mb-4 focus:outline-none focus:ring focus:border-blue-300" required />
+            <input type="hidden" name="orderNumber" id="orderNumberInput" />
+            <div class="flex justify-end gap-2">
+                <button type="button" onclick="closePasswordModal()"
+                        class="px-4 py-2 bg-gray-300 hover:bg-gray-400 text-sm rounded">
+                    취소
+                </button>
+                <button type="submit"
+                        class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white text-sm rounded">
+                    확인
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!--반품모달-->
+<!-- 반품 요청 모달 -->
+<div id="refundModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 hidden z-50">
+    <div class="bg-white p-6 rounded-xl shadow-xl w-full max-w-md relative">
+        <!-- 닫기 버튼 -->
+        <button onclick="closeRefundModal()" class="absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-xl font-bold">
+            &times;
+        </button>
+
+        <h2 class="text-lg font-semibold mb-4">반품 요청</h2>
+
+        <form method="post" action="/guest/main-non-member-order-detail/refund" id="guestRefundForm">
+            <!-- orderNumber hidden -->
+            <input type="hidden" name="orderNumber" id="refundOrderNumberInput" />
+
+            <!-- 비밀번호 -->
+            <label class="block text-sm font-medium text-gray-700 mb-1">비밀번호</label>
+            <input type="password" name="password" required
+                   class="w-full mb-4 px-3 py-2 border rounded focus:outline-none focus:ring focus:border-blue-300" placeholder="비밀번호 입력" />
+
+            <!-- 반품 사유 -->
+            <label class="block text-sm font-medium text-gray-700 mb-1">반품 사유</label>
+            <select name="reason" required
+                    class="w-full mb-4 px-3 py-2 border rounded focus:outline-none focus:ring focus:border-blue-300">
+                <option value="">사유 선택</option>
+                <option value="JUST">단순 변심</option>
+                <option value="DAMAGED">상품 파손</option>
+            </select>
+
+            <div class="flex justify-end gap-2">
+                <button type="button" onclick="closeRefundModal()"
+                        class="px-4 py-2 bg-gray-300 hover:bg-gray-400 text-sm rounded">
+                    취소
+                </button>
+                <button type="submit"
+                        class="px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white text-sm rounded">
+                    반품 요청
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<!--주문취소용 스크립트-->
+<script>
+    function openPasswordModal(button) {
+        const orderNumber = button.getAttribute('data-order-number');
+        document.getElementById('orderNumberInput').value = orderNumber;
+        document.getElementById('guestCancelForm').action = `/guest/main-non-member-order-detail/cancel`;
+        document.getElementById('passwordModal').classList.remove('hidden');
+    }
+
+    function closePasswordModal() {
+        document.getElementById('passwordModal').classList.add('hidden');
+        document.getElementById('guestCancelForm').reset();
+    }
+</script>
+
+<script>
+    // 모달 열기
+    function openRefundModal(button) {
+        const orderNumber = button.getAttribute('data-order-number');
+        document.getElementById('refundOrderNumberInput').value = orderNumber;
+        document.getElementById('refundModal').classList.remove('hidden');
+    }
+
+    // 모달 닫기
+    function closeRefundModal() {
+        const modal = document.getElementById('refundModal');
+        modal.classList.add('hidden');
+        document.getElementById('guestRefundForm').reset();
+    }
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 주문취소 및 반품 처리

## 🔎 작업 상세 내용

- [x] 회원은 주문내역에서 주문상태에따라 주문취소 및 반품 버튼이 나타남
- [x] 비회원은 주문상세조회시 주문상태에따라 주문취소와 반품 버튼이 나타남
- [x] 비회원은 패스워드를 한번 더 입력하여 취소 및 반품
      
## ⏰ Pull Request 마감시간
> 7/3 10:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #73 
