### PR TITLE
issue-82/feat : 주문관리페이지 페이징처리 및 검색추가

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
+++ b/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
@@ -1,8 +1,10 @@
 package shop.wannab.frontservice.order.client;
 
 import jakarta.servlet.http.Cookie;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shop.wannab.frontservice.order.list.deliveryPolicy.dto.DeliveryPolicyRequest;
@@ -77,7 +79,12 @@ public interface OrderApiClient {
      * 주문 관리
      */
     @GetMapping("/api/admin/orders")
-    PageResponse<OrderLookupResponse> getAllOrders(@RequestParam int page,
+    PageResponse<OrderLookupResponse> getAllOrders(@RequestParam(required = false) Long orderId,
+                                                   @RequestParam(required = false) String orderName,
+                                                   @RequestParam(required = false) OrderStatus orderStatus,
+                                                   @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+                                                   @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+                                                   @RequestParam int page,
                                                    @RequestParam int size);
 
     @PostMapping("/api/admin/orders/{orderId}")
@@ -102,7 +109,7 @@ public interface OrderApiClient {
      */
     @GetMapping("/api/orders")
     PageResponse<OrderLookupResponse> getOrdersByUser(@RequestParam int page,
-                                                    @RequestParam int size);
+                                                      @RequestParam int size);
 
 
     /**

--- a/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/OrderManagementController.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/OrderManagementController.java
@@ -1,6 +1,8 @@
 package shop.wannab.frontservice.order.list.ordersManagement;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,13 +23,34 @@ public class OrderManagementController {
     private final OrderApiClient orderApiClient;
 
     @GetMapping
-    public String orderPage(@RequestParam(defaultValue = "0") int page,
+    public String orderPage(@RequestParam(required = false) Long orderId,
+                            @RequestParam(required = false) String orderName,
+                            @RequestParam(required = false) OrderStatus orderStatus,
+                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+                            @RequestParam(defaultValue = "0") int page,
                             @RequestParam(defaultValue = "20") int size,
-                            Model model){
+                            Model model) {
 
-        PageResponse<OrderLookupResponse> response = orderApiClient.getAllOrders(page, size);
+        PageResponse<OrderLookupResponse> response = orderApiClient.getAllOrders(
+                orderId,
+                orderName,
+                orderStatus,
+                from,
+                to,
+                page,
+                size
+        );
+
         model.addAttribute("orders", response.getContent());
         model.addAttribute("page", response);
+
+        // 검색 조건 다시 뷰에 전달해서 form value에 반영
+        model.addAttribute("orderId", orderId);
+        model.addAttribute("orderName", orderName);
+        model.addAttribute("orderStatus", orderStatus);
+        model.addAttribute("from", from);
+        model.addAttribute("to", to);
 
         return "admin/order";
     }

--- a/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/OrderManagementController.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/OrderManagementController.java
@@ -1,17 +1,20 @@
 package shop.wannab.frontservice.order.list.ordersManagement;
 
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import shop.wannab.frontservice.order.client.OrderApiClient;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderLookupResponse;
+import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderSearchDto;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderStatus;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.PageResponse;
 
@@ -23,21 +26,17 @@ public class OrderManagementController {
     private final OrderApiClient orderApiClient;
 
     @GetMapping
-    public String orderPage(@RequestParam(required = false) Long orderId,
-                            @RequestParam(required = false) String orderName,
-                            @RequestParam(required = false) OrderStatus orderStatus,
-                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+    public String orderPage(@Valid @ModelAttribute OrderSearchDto orderSearchDto,
                             @RequestParam(defaultValue = "0") int page,
                             @RequestParam(defaultValue = "20") int size,
                             Model model) {
 
         PageResponse<OrderLookupResponse> response = orderApiClient.getAllOrders(
-                orderId,
-                orderName,
-                orderStatus,
-                from,
-                to,
+                orderSearchDto.getOrderId(),
+                orderSearchDto.getOrderName(),
+                orderSearchDto.getOrderStatus(),
+                orderSearchDto.getFrom(),
+                orderSearchDto.getTo(),
                 page,
                 size
         );
@@ -46,11 +45,11 @@ public class OrderManagementController {
         model.addAttribute("page", response);
 
         // 검색 조건 다시 뷰에 전달해서 form value에 반영
-        model.addAttribute("orderId", orderId);
-        model.addAttribute("orderName", orderName);
-        model.addAttribute("orderStatus", orderStatus);
-        model.addAttribute("from", from);
-        model.addAttribute("to", to);
+        model.addAttribute("orderId", orderSearchDto.getOrderId());
+        model.addAttribute("orderName", orderSearchDto.getOrderName());
+        model.addAttribute("orderStatus", orderSearchDto.getOrderStatus());
+        model.addAttribute("from", orderSearchDto.getFrom());
+        model.addAttribute("to", orderSearchDto.getTo());
 
         return "admin/order";
     }

--- a/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderSearchDto.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderSearchDto.java
@@ -1,0 +1,20 @@
+package shop.wannab.frontservice.order.list.ordersManagement.dto;
+
+import java.time.LocalDate;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/**
+ * 관리자가 주문검색에 사용할 dto
+ */
+
+@Data
+public class OrderSearchDto {
+    private Long orderId;
+    private String orderName;
+    private OrderStatus orderStatus;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate from;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate to;
+}

--- a/src/main/resources/templates/admin/order.html
+++ b/src/main/resources/templates/admin/order.html
@@ -11,6 +11,49 @@
       <span th:text="${message}"></span>
     </div>
 
+    <!-- 검색 폼 -->
+    <form th:action="@{/admin/order}" method="get" class="mb-6 flex flex-wrap gap-4 items-end">
+      <div>
+        <label for="orderId" class="block text-sm font-medium text-gray-700">주문번호</label>
+        <input type="text" id="orderId" name="orderId" th:value="${orderId}"
+               class="mt-1 px-3 py-2 border rounded w-40 text-sm" placeholder="주문번호" />
+      </div>
+
+      <div>
+        <label for="orderName" class="block text-sm font-medium text-gray-700">주문명</label>
+        <input type="text" id="orderName" name="orderName" th:value="${orderName}"
+               class="mt-1 px-3 py-2 border rounded w-40 text-sm" placeholder="주문명" />
+      </div>
+
+      <div>
+        <label for="orderStatus" class="block text-sm font-medium text-gray-700">상태</label>
+        <select id="orderStatus" name="orderStatus" class="mt-1 px-3 py-2 border rounded w-36 text-sm">
+          <option value="">전체</option>
+          <option value="PENDING" th:selected="${orderStatus == 'PENDING'}">대기</option>
+          <option value="SHIPPING" th:selected="${orderStatus == 'SHIPPING'}">배송중</option>
+          <option value="COMPLETED" th:selected="${orderStatus == 'COMPLETED'}">배송 완료</option>
+          <option value="RETURNED" th:selected="${orderStatus == 'RETURNED'}">반품</option>
+          <option value="CANCELLED" th:selected="${orderStatus == 'CANCELLED'}">주문취소</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700">주문일자</label>
+        <div class="flex gap-2">
+          <input type="date" name="from" th:value="${from}" class="px-3 py-2 border rounded text-sm" />
+          <span class="text-sm">~</span>
+          <input type="date" name="to" th:value="${to}" class="px-3 py-2 border rounded text-sm" />
+        </div>
+      </div>
+
+      <div>
+        <button type="submit" class="mt-1 px-4 py-2 bg-blue-500 text-white rounded text-sm hover:bg-blue-600">
+          검색
+        </button>
+      </div>
+    </form>
+
+
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-sky-100">
@@ -59,5 +102,37 @@
         </tbody>
       </table>
     </div>
+  </div>
+
+
+
+  <!-- 페이징 -->
+  <div class="mt-6 flex justify-center" th:if="${page.totalPages > 1}">
+    <nav class="inline-flex rounded-md shadow-sm -space-x-px" aria-label="Pagination">
+      <a th:href="@{/admin/order(page=${page.number - 1}, size=${page.size},
+                          orderId=${orderId}, orderName=${orderName},
+                          orderStatus=${orderStatus}, from=${from}, to=${to})}"
+         th:if="${!page.first}"
+         class="px-3 py-2 border border-gray-300 bg-white text-sm text-gray-500 hover:bg-gray-50">
+        이전
+      </a>
+
+      <a th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
+         th:href="@{/admin/order(page=${i}, size=${page.size},
+                   orderId=${orderId}, orderName=${orderName},
+                   orderStatus=${orderStatus}, from=${from}, to=${to})}"
+         th:text="${i + 1}"
+         th:classappend="${i == page.number} ? 'bg-blue-500 text-white' : 'bg-white text-gray-700 hover:bg-gray-100'"
+         class="px-3 py-2 border border-gray-300 text-sm">
+      </a>
+
+      <a th:href="@{/admin/order(page=${page.number + 1}, size=${page.size},
+                          orderId=${orderId}, orderName=${orderName},
+                          orderStatus=${orderStatus}, from=${from}, to=${to})}"
+         th:if="${!page.last}"
+         class="px-3 py-2 border border-gray-300 bg-white text-sm text-gray-500 hover:bg-gray-50">
+        다음
+      </a>
+    </nav>
   </div>
 </div>


### PR DESCRIPTION

## 🥳 어떤 기능을 구현했나요?

> 관리자는 주문관리페이지에서 조건을 추가해서 검색할 수 있다.

## 🔎 작업 상세 내용

- [x] 한 페이지당 20개씩 페이징 처리
- [x] 주문번호, 주문명, 상태, 기간 등을 설정하여 주문목록을 조회 할 수있다.
      
## ⏰ Pull Request 마감시간
> 18:00

## 📚 참고할만한 자료(선택)
![image](https://github.com/user-attachments/assets/dd3aa482-aca0-4b1b-93fa-713f58b96074)


## 🔗 관련 이슈
Closes #82 
