### PR TITLE
fix/issue-94 : 비회원 주문조회 및 취소,반품수정

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
+++ b/src/main/java/shop/wannab/frontservice/order/client/OrderApiClient.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import shop.wannab.frontservice.order.list.deliveryPolicy.dto.DeliveryPolicyRequest;
 import shop.wannab.frontservice.order.list.deliveryPolicy.dto.DeliveryPolicyResponse;
 import shop.wannab.frontservice.order.dto.*;
+import shop.wannab.frontservice.order.list.orderDetail.dto.GuestOrderRequest;
 import shop.wannab.frontservice.order.list.orderDetail.dto.OrderDetailResponse;
 import shop.wannab.frontservice.order.list.orderDetail.dto.RefundReason;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderLookupResponse;
@@ -101,9 +102,8 @@ public interface OrderApiClient {
     /**
      * 주문 상세 조회 - 비회원
      */
-    @GetMapping("/api/orders/guest")
-    OrderDetailResponse getGuestOrderDetail(@RequestParam Long orderId,
-                                            @RequestParam String password);
+    @PostMapping("/api/orders/guest")
+    OrderDetailResponse getGuestOrderDetail(@RequestBody GuestOrderRequest request);
 
     /**회원주문목록 조회
      */
@@ -129,15 +129,13 @@ public interface OrderApiClient {
      * 비회원 주문취소
      */
     @PostMapping("/api/orders/guest/cancel")
-    public ResponseEntity<Void> cancelGuestOrder(@RequestParam Long orderId,
-                                                 @RequestParam String password);
+    public ResponseEntity<Void> cancelGuestOrder(@RequestBody GuestOrderRequest request);
 
     /**
      * 비회원 반품
      */
     @PostMapping("/api/orders/guest/refund")
-    public ResponseEntity<Void> refundGuestOrder(@RequestParam Long orderId,
-                                                 @RequestParam String password,
+    public ResponseEntity<Void> refundGuestOrder(@RequestBody GuestOrderRequest request,
                                                  @RequestParam RefundReason reason);
 
 

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/OrderDetailController.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/OrderDetailController.java
@@ -6,11 +6,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import shop.wannab.frontservice.order.client.OrderApiClient;
+import shop.wannab.frontservice.order.list.orderDetail.dto.GuestOrderRequest;
 import shop.wannab.frontservice.order.list.orderDetail.dto.OrderDetailResponse;
 import shop.wannab.frontservice.order.list.orderDetail.dto.RefundReason;
 import shop.wannab.frontservice.order.list.ordersManagement.dto.OrderLookupResponse;
@@ -26,16 +29,34 @@ public class OrderDetailController {
     private final OrderApiClient orderApiClient;
     private final UserService userService;
 
+    /**
+     * 입력 폼
+     */
+    @GetMapping("/guest/main-non-member-order-form")
+    public String showGuestOrderLookupPage() {
+        return "guest/main-non-member-order";
+    }
+
+    /**
+     * 조회 폼
+     */
+    @GetMapping("/guest/main-non-member-order-detail")
+    public String getGuestOrderPageFromRedirect(@ModelAttribute("request") GuestOrderRequest request,
+                                                Model model) {
+        OrderDetailResponse order = orderApiClient.getGuestOrderDetail(request);
+        model.addAttribute("order", order);
+        model.addAttribute("isGuest", true);
+        return "user/order-detail";
+    }
 
     //TODO : 비밀번호 url에 표시안되게 수정하기
     /**
      비회원 주문상세조회
      */
-    @GetMapping("/guest/main-non-member-order-detail")
-    public String getGuestOrderPage(@RequestParam Long orderId,
-                                    @RequestParam String password,
+    @PostMapping("/guest/main-non-member-order-detail")
+    public String getGuestOrderPage(@ModelAttribute GuestOrderRequest request,
                                     Model model){
-        OrderDetailResponse order = orderApiClient.getGuestOrderDetail(orderId, password);
+        OrderDetailResponse order = orderApiClient.getGuestOrderDetail(request);
         model.addAttribute("order", order);
         model.addAttribute("isGuest", true);
         return "user/order-detail";
@@ -112,29 +133,28 @@ public class OrderDetailController {
      * 비회원 주문취소
      */
     @PostMapping("/guest/main-non-member-order-detail/cancel")
-    public String guestOrderCancel(@RequestParam Long orderNumber,
-                                   @RequestParam String password,
+    public String guestOrderCancel(@ModelAttribute GuestOrderRequest request,
                                    RedirectAttributes redirectAttributes){
-        orderApiClient.cancelGuestOrder(orderNumber, password);
+        orderApiClient.cancelGuestOrder(request);
         redirectAttributes.addFlashAttribute("message", "주문취소요청이 처리되었습니다.");
+        redirectAttributes.addFlashAttribute("request", request);
 
-        return "redirect:/guest/main-non-member-order-detail?orderId=" + orderNumber + "&password=" + password;
+        return "redirect:/guest/main-non-member-order-detail";
     }
 
     /**
      * 비회원 반품
      */
     @PostMapping("/guest/main-non-member-order-detail/refund")
-    public String guestOrderRefund(@RequestParam Long orderNumber,
-                                   @RequestParam String password,
+    public String guestOrderRefund(@ModelAttribute GuestOrderRequest request,
                                    @RequestParam String reason,
                                    RedirectAttributes redirectAttributes){
         RefundReason refundReason = RefundReason.valueOf(reason);
-        orderApiClient.refundGuestOrder(orderNumber, password, refundReason);
+        orderApiClient.refundGuestOrder(request, refundReason);
 
         redirectAttributes.addFlashAttribute("message", "주문반품요청이 처리되었습니다.");
 
-        return "redirect:/guest/main-non-member-order-detail?orderId=" + orderNumber + "&password=" + password;
+        return "redirect:/guest/main-non-member-order-detail";
     }
 
 

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/GuestOrderRequest.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/GuestOrderRequest.java
@@ -1,0 +1,12 @@
+package shop.wannab.frontservice.order.list.orderDetail.dto;
+
+import lombok.Data;
+
+/**
+ * 게스트 주문조회 및 반품,취소 시 필요
+ */
+@Data
+public class GuestOrderRequest {
+    private Long orderId;
+    private String password;
+}

--- a/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderDetailResponse.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/orderDetail/dto/OrderDetailResponse.java
@@ -21,7 +21,7 @@ public class OrderDetailResponse {
      * 주문 번호
      * (일단 order ID 사용)
      */
-    private Long orderNumber;
+    private Long orderId;
 
     /**
      * 주문 일시

--- a/src/main/resources/templates/components/header.html
+++ b/src/main/resources/templates/components/header.html
@@ -4,7 +4,7 @@
     <span th:onclick="|window.location.href='@{/user/main-cart}'|">🛒</span>
     <!--회원 비회원 분기처리 필요-->
     <span th:onclick="|window.location.href='@{/user/mypage}'|">👤</span>
-    <span th:onclick="|window.location.href='@{/guest/main-non-member-order}'|">📋</span>
+    <span th:onclick="|window.location.href='@{/guest/main-non-member-order-form}'|">📋</span>
 
     <span th:onclick="|window.location.href='@{/auth/logout}'|">🔓</span>
   </div>

--- a/src/main/resources/templates/guest/main-non-member-order.html
+++ b/src/main/resources/templates/guest/main-non-member-order.html
@@ -18,7 +18,7 @@
         <div class="non-member-order-box">
             <h2 class="non-member-order-title">비회원 주문 조회</h2>
 
-            <form class="non-member-order-form" method="get" action="/guest/main-non-member-order-detail">
+            <form class="non-member-order-form" method="post" action="/guest/main-non-member-order-detail">
                 <label for="orderId">Order Id</label>
                 <input type="text" id="orderId" name="orderId" placeholder="주문번호를 입력하세요" required />
 

--- a/src/main/resources/templates/user/order-detail.html
+++ b/src/main/resources/templates/user/order-detail.html
@@ -19,7 +19,7 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-sm">
             <div>
                 <p class="text-gray-500">주문번호</p>
-                <p class="font-medium" th:text="${order.orderNumber}">1001</p>
+                <p class="font-medium" th:text="${order.orderId}">1001</p>
             </div>
             <div>
                 <p class="text-gray-500">주문일시</p>
@@ -41,7 +41,7 @@
                     <button
                             type="button"
                             th:if="${isGuest and order.orderStatus.name() == 'PENDING'}"
-                            th:attr="data-order-number=${order.orderNumber}"
+                            th:attr="data-order-id=${order.orderId}"
                             class="text-xs px-2 py-1 bg-red-500 hover:bg-red-600 text-white rounded-md"
                             onclick="openPasswordModal(this)">
                         주문 취소
@@ -50,7 +50,7 @@
                     <button
                         type="button"
                         th:if="${isGuest and order.orderStatus.name() == 'COMPLETED'}"
-                        th:attr="data-order-number=${order.orderNumber}"
+                        th:attr="data-order-id=${order.orderId}"
                         class="text-xs px-2 py-1 bg-yellow-500 hover:bg-yellow-600 text-white rounded-md"
                         onclick="openRefundModal(this)">
                         반품 요청
@@ -92,7 +92,7 @@
         <form id="guestCancelForm" method="post" action="">
             <input type="password" name="password" placeholder="비밀번호 입력"
                    class="w-full px-3 py-2 border rounded mb-4 focus:outline-none focus:ring focus:border-blue-300" required />
-            <input type="hidden" name="orderNumber" id="orderNumberInput" />
+            <input type="hidden" name="orderId" id="orderIdInput" />
             <div class="flex justify-end gap-2">
                 <button type="button" onclick="closePasswordModal()"
                         class="px-4 py-2 bg-gray-300 hover:bg-gray-400 text-sm rounded">
@@ -119,8 +119,8 @@
         <h2 class="text-lg font-semibold mb-4">반품 요청</h2>
 
         <form method="post" action="/guest/main-non-member-order-detail/refund" id="guestRefundForm">
-            <!-- orderNumber hidden -->
-            <input type="hidden" name="orderNumber" id="refundOrderNumberInput" />
+            <!-- orderId hidden -->
+            <input type="hidden" name="orderId" id="refundOrderIdInput" />
 
             <!-- 비밀번호 -->
             <label class="block text-sm font-medium text-gray-700 mb-1">비밀번호</label>
@@ -153,8 +153,8 @@
 <!--주문취소용 스크립트-->
 <script>
     function openPasswordModal(button) {
-        const orderNumber = button.getAttribute('data-order-number');
-        document.getElementById('orderNumberInput').value = orderNumber;
+        const orderId = button.getAttribute('data-order-id');
+        document.getElementById('orderIdInput').value = orderId;
         document.getElementById('guestCancelForm').action = `/guest/main-non-member-order-detail/cancel`;
         document.getElementById('passwordModal').classList.remove('hidden');
     }
@@ -168,8 +168,8 @@
 <script>
     // 모달 열기
     function openRefundModal(button) {
-        const orderNumber = button.getAttribute('data-order-number');
-        document.getElementById('refundOrderNumberInput').value = orderNumber;
+        const orderId = button.getAttribute('data-order-id');
+        document.getElementById('refundOrderIdInput').value = orderId;
         document.getElementById('refundModal').classList.remove('hidden');
     }
 


### PR DESCRIPTION

## 🥳 어떤 기능을 구현했나요?

> 비회원 주문조회, 취소, 반품에 대해 주문번호와 password를 입력하여 조회를하면 URL에 노출되는 부분을 수정

## 🔎 작업 상세 내용

- [x] DTO를 만들어서 orderId와 password를 받음
- [x] 기존 비회원 주문조회 GetMapping에서 GetMapping과 PostMapping으로 분리
      
## ⏰ Pull Request 마감시간
> 18:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #94 
