### PR TITLE
fix: 마이페이지-회원정보 변경 기능

### DIFF
--- a/src/main/java/shop/wannab/frontservice/user/client/UserClient.java
+++ b/src/main/java/shop/wannab/frontservice/user/client/UserClient.java
@@ -5,7 +5,6 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -25,7 +24,7 @@ public interface UserClient {
     @GetMapping("/api/users")
     ResponseEntity<UserPageResponse> readUser();
 
-    @PatchMapping("/api/users")
+    @PostMapping("/api/users")
     ResponseEntity<UserPageResponse> updateUser(@RequestBody UserUpdateRequest userUpdateRequest);
 
     @DeleteMapping("/api/users")

--- a/src/main/java/shop/wannab/frontservice/user/controller/UserController.java
+++ b/src/main/java/shop/wannab/frontservice/user/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     @PatchMapping("/users")
     public String updateUser(@ModelAttribute @Valid UserUpdateRequest userUpdateRequest) {
         userService.updateUser(userUpdateRequest);
-        return "/user/mypage-edit";
+        return "redirect:/user/mypage";
     }
 
     @DeleteMapping("/users")

--- a/src/main/java/shop/wannab/frontservice/user/dto/UserUpdateRequest.java
+++ b/src/main/java/shop/wannab/frontservice/user/dto/UserUpdateRequest.java
@@ -9,5 +9,5 @@ public record UserUpdateRequest(
         @NotBlank String name,
         @NotBlank @Email String email,
         @NotBlank String nickname,
-        @NotBlank @Pattern(regexp = "^\\d{11}$") String phone) {
+        @NotBlank @Pattern(regexp = "^\\d{12}$") String phone) {
 }

--- a/src/main/resources/templates/user/mypage-edit.html
+++ b/src/main/resources/templates/user/mypage-edit.html
@@ -3,7 +3,8 @@
       th:replace="~{layout/user-layout :: layout (
       '마이 페이지',
       ~{::body},
-      ~{::head}
+      ~{::head},
+      false
     )}">
 
 <head>
@@ -43,11 +44,11 @@
           </tr>
           <tr>
             <th><label for="birth">생일</label></th>
-            <td><input type="date" id="birth" name="birth" th:value="${user.birth}" required /></td>
+            <td><input type="text" id="birth" name="birth" th:value="${user.birth}" readonly required /></td>
           </tr>
           <tr>
             <th><label for="userId">아이디</label></th>
-            <td><input type="text" id="userId" name="userId" th:value="${user.id}" required /></td>
+            <td><input type="text" id="userId" name="userId" th:value="${user.id}" readonly required/></td>
           </tr>
           <tr>
             <th><label for="password">패스워드</label></th>


### PR DESCRIPTION

- <106/이슈이름 : 회원정보 변경 기능 에러 수정>  (작성 후 지워주세요 )

## 🥳 어떤 기능을 구현했나요?

> 회원정보 변경 기능 에러 수정

## 🔎 작업 상세 내용

- [x] feign client에서 patch요청을 post로 변경
- [x] service의 반환객체 수정
- [x] 마이페이지-회원정보의 아이디, 생일 필드 readonly로 변경
      
## ⏰ Pull Request 마감시간
>  8일 19:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes # 106
