### PR TITLE
휴면상태해제 : <46/user-unlock>

### DIFF
--- a/src/main/java/shop/wannab/frontservice/auth/controller/AuthController.java
+++ b/src/main/java/shop/wannab/frontservice/auth/controller/AuthController.java
@@ -1,19 +1,20 @@
 package shop.wannab.frontservice.auth.controller;
 
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import shop.wannab.frontservice.auth.controller.request.LoginRequest;
-import shop.wannab.frontservice.auth.controller.response.LoginResponse;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import shop.wannab.frontservice.auth.controller.request.UnlockRequest;
+
 import shop.wannab.frontservice.auth.service.AuthService;
 import shop.wannab.frontservice.user.dto.UserCreateForm;
-import shop.wannab.frontservice.utils.CookieUtils;
 
 @Controller
 @RequestMapping("/auth")
@@ -31,6 +32,35 @@ public class AuthController {
             return "redirect:/auth/login";
         }
         return "redirect:/";
+    }
+
+    @GetMapping("/unlock")
+    public String unlock(@RequestParam("userId") String userId, Model model) {
+        model.addAttribute("userId", userId);
+        return "auth/unlock";
+    }
+
+
+    @PostMapping("/unlock/verify")
+    public String verifyCode(@RequestParam String userId,
+                             @RequestParam int authCode,
+                             Model model) {
+        boolean result = authService.verifyDormantAccount(new UnlockRequest(userId, authCode));
+
+        if (result) {
+            return "redirect:/auth/logout";
+        } else {
+            model.addAttribute("userId", userId);
+            model.addAttribute("error", "인증코드가 틀렸습니다. 다시 입력해주세요.");
+            return "user/unlock";
+        }
+    }
+
+    @PostMapping("/unlock/request")
+    @ResponseBody
+    public ResponseEntity resendAuthCode(@RequestParam String userId) {
+        authService.resendDormantAuthCode(userId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/shop/wannab/frontservice/auth/controller/request/UnlockRequest.java
+++ b/src/main/java/shop/wannab/frontservice/auth/controller/request/UnlockRequest.java
@@ -1,0 +1,7 @@
+package shop.wannab.frontservice.auth.controller.request;
+
+public record UnlockRequest(
+        String userId,
+        int authenticationCode
+) {
+}

--- a/src/main/java/shop/wannab/frontservice/auth/exception/DeletedUserException.java
+++ b/src/main/java/shop/wannab/frontservice/auth/exception/DeletedUserException.java
@@ -1,6 +1,8 @@
 package shop.wannab.frontservice.auth.exception;
 
-public class DeletedUserException extends RuntimeException {
+import org.springframework.security.core.AuthenticationException;
+
+public class DeletedUserException extends AuthenticationException {
     public DeletedUserException(String message) {
         super(message);
     }

--- a/src/main/java/shop/wannab/frontservice/auth/exception/InactiveUserException.java
+++ b/src/main/java/shop/wannab/frontservice/auth/exception/InactiveUserException.java
@@ -1,6 +1,9 @@
 package shop.wannab.frontservice.auth.exception;
 
-public class InactiveUserException extends RuntimeException {
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InactiveUserException extends AuthenticationException {
     public InactiveUserException(String message) {
         super(message);
     }

--- a/src/main/java/shop/wannab/frontservice/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/shop/wannab/frontservice/auth/filter/CustomLoginFilter.java
@@ -15,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import shop.wannab.frontservice.auth.CustomUserDetails;
 import shop.wannab.frontservice.auth.controller.request.TokenRequest;
 import shop.wannab.frontservice.auth.controller.response.LoginResponse;
+import shop.wannab.frontservice.auth.exception.InactiveUserException;
 import shop.wannab.frontservice.auth.service.AuthClient;
 import shop.wannab.frontservice.utils.CookieUtils;
 
@@ -58,5 +59,25 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         response.addCookie(CookieUtils.createCookie("refresh_token", token.refreshToken(), 7 * 24 * 60, true));
         response.sendRedirect("/");
     }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException {
+        // 예외 직접 처리
+        Throwable rootCause = failed.getCause();
+
+        if (rootCause instanceof InactiveUserException inactive) {
+            log.info("휴면 계정 로그인 시도");
+            response.sendRedirect("/auth/unlock?userId=" + inactive.getMessage());
+        } else {
+            log.info("로그인 실패");
+            response.sendRedirect("/auth/login?error=로그인 실패");
+        }
+
+        // 아래 호출 생략하면 Spring이 로그를 안 찍습니다.
+        // super.unsuccessfulAuthentication(request, response, failed);
+    }
+
 
 }

--- a/src/main/java/shop/wannab/frontservice/auth/handler/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/shop/wannab/frontservice/auth/handler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,29 @@
+package shop.wannab.frontservice.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import shop.wannab.frontservice.auth.exception.DeletedUserException;
+import shop.wannab.frontservice.auth.exception.InactiveUserException;
+
+@Component
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        Throwable throwable = exception.getCause();
+        if (throwable instanceof InactiveUserException inactive) {
+
+            response.sendRedirect("/auth/unlock?userId=" + inactive.getMessage());
+            return;
+        } else {
+            response.sendRedirect("/auth/login");
+        }
+    }
+}

--- a/src/main/java/shop/wannab/frontservice/auth/service/AuthClient.java
+++ b/src/main/java/shop/wannab/frontservice/auth/service/AuthClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import shop.wannab.frontservice.auth.controller.request.LoginRequest;
 import shop.wannab.frontservice.auth.controller.request.ReissueRequest;
 import shop.wannab.frontservice.auth.controller.request.TokenRequest;
+import shop.wannab.frontservice.auth.controller.request.UnlockRequest;
 import shop.wannab.frontservice.auth.controller.response.LoginResponse;
 import shop.wannab.frontservice.auth.controller.response.ReissueResponse;
 import shop.wannab.frontservice.auth.domain.PaycoLoginRequest;
@@ -38,4 +39,9 @@ public interface AuthClient {
     @PostMapping("/api/auth/login/payco")
     ResponseEntity<Response<PaycoLoginResponse>> paycoLogin(@RequestBody PaycoLoginRequest request);
 
+    @PostMapping("/api/auth/unlock/request")
+    ResponseEntity unlockRequest(@RequestBody String userId);
+
+    @PostMapping("/api/auth/unlock/verify")
+    boolean unlockVerifiy(@RequestBody UnlockRequest unlockRequest);
 }

--- a/src/main/java/shop/wannab/frontservice/auth/service/AuthService.java
+++ b/src/main/java/shop/wannab/frontservice/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package shop.wannab.frontservice.auth.service;
 import io.jsonwebtoken.JwtException;
 import shop.wannab.frontservice.auth.controller.request.LoginRequest;
 import shop.wannab.frontservice.auth.controller.request.TokenRequest;
+import shop.wannab.frontservice.auth.controller.request.UnlockRequest;
 import shop.wannab.frontservice.auth.controller.response.LoginResponse;
 import shop.wannab.frontservice.auth.domain.TokenResponse;
 import shop.wannab.frontservice.user.dto.UserCreateForm;
@@ -22,4 +23,13 @@ public interface AuthService {
      */
     LoginResponse generateToken(TokenRequest tokenRequest);
 
+    /**
+     * 휴면해제 인증코드 체크
+     */
+    boolean verifyDormantAccount(UnlockRequest unlockRequest);
+
+    /**
+     * 휴면해제 인증코드 요청
+     */
+    void resendDormantAuthCode(String userId);
 }

--- a/src/main/java/shop/wannab/frontservice/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/shop/wannab/frontservice/auth/service/CustomUserDetailsService.java
@@ -20,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = authClient.getUsers(username);
         switch (user.getState()) {
-            case INACTIVATE -> throw new InactiveUserException("휴면 계정입니다");
+            case INACTIVATE -> throw new InactiveUserException(username);
             case DELETED -> throw new DeletedUserException("삭제된 계정입니다");
         }
         return new CustomUserDetails(user);

--- a/src/main/java/shop/wannab/frontservice/auth/service/Impl/AuthServiceImpl.java
+++ b/src/main/java/shop/wannab/frontservice/auth/service/Impl/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import shop.wannab.frontservice.auth.controller.request.LoginRequest;
 import shop.wannab.frontservice.auth.controller.request.ReissueRequest;
+import shop.wannab.frontservice.auth.controller.request.UnlockRequest;
 import shop.wannab.frontservice.auth.controller.response.LoginResponse;
 import shop.wannab.frontservice.auth.controller.response.ReissueResponse;
 import shop.wannab.frontservice.auth.controller.request.TokenRequest;
@@ -78,6 +79,16 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public LoginResponse generateToken(TokenRequest tokenRequest) {
         return authClient.getToken(tokenRequest);
+    }
+
+    @Override
+    public boolean verifyDormantAccount(UnlockRequest unlockRequest) {
+        return authClient.unlockVerifiy(unlockRequest);
+    }
+
+    @Override
+    public void resendDormantAuthCode(String userId) {
+        authClient.unlockRequest(userId);
     }
 
 }

--- a/src/main/java/shop/wannab/frontservice/global/advice/GlobalControllerAdvice.java
+++ b/src/main/java/shop/wannab/frontservice/global/advice/GlobalControllerAdvice.java
@@ -1,0 +1,15 @@
+//package shop.wannab.frontservice.global.advice;
+//
+//import org.springframework.ui.Model;
+//import org.springframework.web.bind.annotation.ControllerAdvice;
+//import org.springframework.web.bind.annotation.ExceptionHandler;
+//import shop.wannab.frontservice.auth.exception.InactiveUserException;
+//
+//@ControllerAdvice
+//public class GlobalControllerAdvice {
+//    @ExceptionHandler({InactiveUserException.class})
+//    public String handleInactiveUserException(InactiveUserException e, Model model) {
+//        model.addAttribute("userId", e.getMessage());
+//        return "/auth/unlock";
+//    }
+//}

--- a/src/main/java/shop/wannab/frontservice/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/shop/wannab/frontservice/global/advice/GlobalExceptionHandler.java
@@ -1,11 +1,16 @@
 package shop.wannab.frontservice.global.advice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.io.IOException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import shop.wannab.frontservice.auth.domain.Response;
 import shop.wannab.frontservice.book.exception.BookServiceException;
 
 @Slf4j

--- a/src/main/resources/templates/auth/unlock.html
+++ b/src/main/resources/templates/auth/unlock.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/user-layout :: layout (
+      '휴면 계정 인증',
+      ~{::body},
+      ~{::head},
+      false
+    )}">
+
+<head>
+  <title>휴면 계정 인증</title>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const btn = document.getElementById("resendBtn");
+      btn.addEventListener("click", function () {
+        const userId = btn.dataset.userId;
+
+        fetch('/auth/unlock/request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ userId })
+        })
+                .then(response => {
+                  const msg = document.getElementById('resendMessage');
+                  if (response.ok) {
+                    msg.innerText = '인증 코드가 재전송되었습니다.';
+                    msg.style.color = 'green';
+                  } else {
+                    msg.innerText = '전송에 실패했습니다.';
+                    msg.style.color = 'red';
+                  }
+                });
+      });
+    });
+  </script>
+</head>
+
+<body>
+<section class="unlock-section">
+  <h2>휴면 계정 인증</h2>
+  <p th:text="|ID: ${userId}|"></p>
+
+  <!-- 계정 활성화 폼 -->
+  <form th:action="@{/auth/unlock/verify}" method="post" id="verifyForm">
+    <input type="hidden" name="userId" th:value="${userId}" />
+    <label for="authCode">인증 코드</label>
+    <input type="text" id="authCode" name="authCode" placeholder="6자리 숫자" required maxlength="6" />
+    <button type="submit">계정 활성화</button>
+    <p th:if="${error}" th:text="${error}" style="color:red;"></p>
+  </form>
+
+  <!-- 인증 코드 재전송 버튼 -->
+  <div style="margin-top: 10px;">
+    <button type="button" id="resendBtn" th:data-user-id="${userId}">인증 코드 전송</button>
+    <p id="resendMessage"></p>
+  </div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 로그인 시 State.INACTIVATE 라면 휴면상태해제 페이지로 이동하여 인증코드 확인 후 해제

## 🔎 작업 상세 내용

- [x] 로그인 했을때 UserDetailsService에서 사용자의 상태 확인하여 exception throw 
- [x] LoginFilter의 unsuccessful메서드에서 로그인 실패에 대한 로직 작성(예외 확인하여 인증페이지로 이동)
- [x] 인증코드 발급, 검증 버튼으로 휴면상태해제하여 정상처리
      
## ⏰ Pull Request 마감시간
> 2025.07.09 12:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #이슈번호
