### PR TITLE
issue-111/feat : 결제실패에 대한 주문상태처리

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderStatus.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderStatus.java
@@ -3,8 +3,10 @@ package shop.wannab.frontservice.order.list.ordersManagement.dto;
 
 public enum OrderStatus {
     PENDING,
+    PAID,
     SHIPPING,
     COMPLETED,
     RETURNED,
-    CANCELLED;
+    CANCELLED,
+    FAILED;
 }

--- a/src/main/resources/templates/admin/order.html
+++ b/src/main/resources/templates/admin/order.html
@@ -29,11 +29,13 @@
         <label for="orderStatus" class="block text-sm font-medium text-gray-700">상태</label>
         <select id="orderStatus" name="orderStatus" class="mt-1 px-3 py-2 border rounded w-36 text-sm">
           <option value="">전체</option>
-          <option value="PENDING" th:selected="${orderStatus == 'PENDING'}">대기</option>
+          <option value="PENDING" th:selected="${orderStatus == 'PENDING'}">결제대기</option>
+          <option value="PAID" th:selected="${orderStatus == 'PAID'}">결제완료(배송대기)</option>
           <option value="SHIPPING" th:selected="${orderStatus == 'SHIPPING'}">배송중</option>
           <option value="COMPLETED" th:selected="${orderStatus == 'COMPLETED'}">배송 완료</option>
           <option value="RETURNED" th:selected="${orderStatus == 'RETURNED'}">반품</option>
           <option value="CANCELLED" th:selected="${orderStatus == 'CANCELLED'}">주문취소</option>
+          <option value="FAILED" th:selected="${orderStatus == 'FAILED'}">주문실패</option>
         </select>
       </div>
 
@@ -75,20 +77,22 @@
           <td class="px-6 py-4 text-sm text-gray-800" th:text="${#temporals.format(order.shippedAt, 'yyyy-MM-dd HH:mm')}">출고일시</td>
           <td class="px-6 py-4 text-sm text-gray-800" th:text="${#numbers.formatInteger(order.totalPrice, 3, 'COMMA')} + '원'">총금액</td>
           <td class="px-6 py-4 text-sm font-semibold"
-              th:with="status=${order.orderStatus != null ? order.orderStatus.name() : 'PENDING'}"
+              th:with="status=${order.orderStatus != null ? order.orderStatus.name() : 'PAID'}"
               th:switch="${status}">
-            <span th:case="'PENDING'" class="text-gray-500">대기</span>
-            <span th:case="'SHIPPING'" class="text-green-500">배송중</span>
-            <span th:case="'COMPLETED'" class="text-black">배송 완료</span>
+            <span th:case="'PENDING'" class="text-gray-500">결제대기</span>
+            <span th:case="'PAID'" class="text-blue-600">결제완료(배송대기)</span>
+            <span th:case="'SHIPPING'" class="text-green-600">배송중</span>
+            <span th:case="'COMPLETED'" class="text-gray-800">배송 완료</span>
             <span th:case="'RETURNED'" class="text-red-500">반품</span>
             <span th:case="'CANCELLED'" class="text-orange-500">주문취소</span>
+            <span th:case="'FAILED'" class="text-red-500">주문실패</span>
             <span th:case="*" class="text-yellow-500">알 수 없음</span>
           </td>
           <td class="px-6 py-4">
             <form th:action="@{/admin/order/status/update}" method="post" class="flex items-center gap-2">
               <input type="hidden" name="orderId" th:value="${order.orderId}" />
-              <select name="newStatus" class="p-1 w-28 text-sm border rounded">
-                <option value="PENDING" th:selected="${order.orderStatus.name() == 'PENDING'}">대기</option>
+              <select name="newStatus" class="p-1 w-40 text-sm border rounded">
+                <option value="PAID" th:selected="${order.orderStatus.name() == 'PAID'}">결제완료(배송대기)</option>
                 <option value="SHIPPING" th:selected="${order.orderStatus.name() == 'SHIPPING'}">배송중</option>
                 <option value="COMPLETED" th:selected="${order.orderStatus.name() == 'COMPLETED'}">배송 완료</option>
               </select>

--- a/src/main/resources/templates/guest/main-non-member-order.html
+++ b/src/main/resources/templates/guest/main-non-member-order.html
@@ -3,7 +3,8 @@
       th:replace="~{layout/user-layout :: layout (
       '비회원 주문 조회 페이지',
       ~{::body},
-      ~{::head}
+      ~{::head},
+      false
     )}">
 
 <head>

--- a/src/main/resources/templates/user/mypage-order.html
+++ b/src/main/resources/templates/user/mypage-order.html
@@ -32,9 +32,10 @@
           <strong th:text="'[주문번호] ' + ${order.orderId}"></strong><br />
           <span th:text="'총 금액: ' + ${#numbers.formatInteger(order.totalPrice, 3, 'COMMA')} + '원'"></span><br />
           <span th:switch="${order.orderStatus.name()}">
-            <span th:case="'PENDING'" class="text-gray-500">대기</span>
-            <span th:case="'SHIPPING'" class="text-green-500">배송중</span>
-            <span th:case="'COMPLETED'" class="text-black">배송 완료</span>
+            <span th:case="'PENDING'" class="text-gray-500">결제대기</span>
+            <span th:case="'PAID'" class="text-blue-600">결제완료(배송대기)</span>
+            <span th:case="'SHIPPING'" class="text-green-600">배송중</span>
+            <span th:case="'COMPLETED'" class="text-gray-800">배송 완료</span>
             <span th:case="'RETURNED'" class="text-red-500">반품</span>
             <span th:case="'CANCELLED'" class="text-orange-500">주문취소</span>
             <span th:case="*" class="text-yellow-500">알 수 없음</span>
@@ -52,7 +53,7 @@
                 onclick="openRefundModal(this)">반품
           </span>
           <span class="cancel text-xs text-red-500 cursor-pointer"
-                th:if="${order.orderStatus.name() == 'PENDING'}"
+                th:if="${order.orderStatus.name() == 'PAID'}"
                 th:attr="data-order-id=${order.orderId}"
                 onclick="submitCancel(this)">
               주문 취소

--- a/src/main/resources/templates/user/order-detail.html
+++ b/src/main/resources/templates/user/order-detail.html
@@ -40,11 +40,13 @@
         <div class="mb-4 flex justify-between">
             <span>주문상태</span>
             <span th:switch="${order.orderStatus.name()}">
-                    <span th:case="'PENDING'" class="text-gray-500">대기</span>
+                    <span th:case="'PENDING'" class="text-gray-500">결제대기</span>
+                    <span th:case="'PAID'" class="text-blue-600">결제완료(배송대기)</span>
                     <span th:case="'SHIPPING'" class="text-green-600">배송중</span>
                     <span th:case="'COMPLETED'" class="text-gray-800">배송 완료</span>
                     <span th:case="'RETURNED'" class="text-red-500">반품</span>
                     <span th:case="'CANCELLED'" class="text-orange-500">주문취소</span>
+                    <span th:case="'FAILED'" class="text-red-500">주문실패</span>
                     <span th:case="*" class="text-yellow-500">알 수 없음</span>
             </span>
 
@@ -53,7 +55,7 @@
         <div class="mt-2 flex gap-2 justify-end">
             <button
                     type="button"
-                    th:if="${isGuest and order.orderStatus.name() == 'PENDING'}"
+                    th:if="${isGuest and order.orderStatus.name() == 'PAID'}"
                     th:attr="data-order-id=${order.orderId}"
                     class="text-xs px-3 py-1 bg-red-500 hover:bg-red-600 text-white rounded-md transition"
                     onclick="openPasswordModal(this)">


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 주문버튼을 누르면 결제가 성공하든 안하든 주문데이터가 생성되는데 이로인해 더미데이터들이 쌓여서 해결하기위해 주문상태에 대한 컬럼을 2개 추가(결제완료(배송대기), 주문실패)

## 🔎 작업 상세 내용

- [x] 주문하고 시간내로 결제가 완료되지않을시, 주문실패로 처리
- [x] 관리자는 주문실패에 관한 목록을 주문관리페이지에서 확인가능하지만 회원은 주문내역에서 확인불가
      
## ⏰ Pull Request 마감시간
> 16:00

## 📚 참고할만한 자료(선택)


## 🔗 관련 이슈
Closes #111 
