### PR TITLE
issue-117/주문시 회원주소 선택

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/controller/CartController.java
+++ b/src/main/java/shop/wannab/frontservice/order/controller/CartController.java
@@ -21,8 +21,8 @@ public class CartController {
     private final OrderApiClient orderApiClient;
     private final CartService cartService;
     @GetMapping
-    public String getCartPage(@CookieValue(value = "guestId", required = false) Long guestId, Model model) {
-        if (Objects.isNull(guestId)) {//비회원 && 장바구니에 아무것도 담지 않을시
+    public String getCartPage(@CookieValue(value = "guestId", required = false) Long guestId, @CookieValue(value = "access_token", required = false) String accessToken, Model model) {
+        if (Objects.isNull(guestId) && Objects.isNull(accessToken)) {//비회원 && 장바구니에 아무것도 담지 않을시
             OrderBookInfoListDto emptyCart = new OrderBookInfoListDto(List.of());
             model.addAttribute("cartItems", emptyCart.getOrderBookInfos());
             return "user/main-cart";
@@ -33,8 +33,10 @@ public class CartController {
     }
 
     @PostMapping("/books")
-    public String addItemToCart(@CookieValue(value = "guestId", required = false) Long guestId, @RequestParam Long bookId, HttpServletResponse response) {
-        if (Objects.isNull(guestId)) {//비회원 && 장바구니에 처음 상품 담을시 //TODO: 로그아웃시,jwt토큰 쿠키 아예 지우는지 냅두는지 확인할 필요 ㅇ
+    public String addItemToCart(@CookieValue(value = "guestId", required = false) Long guestId,
+                                @CookieValue(value = "access_token", required = false) String accessToken,
+                                @RequestParam Long bookId, HttpServletResponse response) {
+        if (Objects.isNull(guestId) && Objects.isNull(accessToken)) {//비회원 && 장바구니에 처음 상품 담을시
             GuestCartCookieDto guestCartCookieDto = orderApiClient.createCart();
             cartService.setGuestCookie(guestCartCookieDto, response);
             guestId = guestCartCookieDto.getValue();
@@ -44,16 +46,21 @@ public class CartController {
     }
 
     @PutMapping("/books/{book-id}")
-    public String updateCartItemQuantity(@CookieValue(value = "guestId", required = false) Long guestId, @PathVariable(name = "book-id") Long bookId, @RequestParam int quantity) {
-        if (Objects.nonNull(guestId)) {
+    public String updateCartItemQuantity(@CookieValue(value = "guestId", required = false) Long guestId,
+                                         @CookieValue(value = "access_token", required = false) String accessToken,
+                                         @PathVariable(name = "book-id") Long bookId,
+                                         @RequestParam int quantity) {
+        if (Objects.nonNull(guestId) || Objects.nonNull(accessToken)) {
             orderApiClient.updateCartItemQuantity(guestId, bookId, quantity);
         }
         return "redirect:/user/main-cart";
     }
 
     @DeleteMapping("/books/{book-id}")
-    public String removeCartItem(@CookieValue(value = "guestId", required = false) Long guestId, @PathVariable(name = "book-id") Long bookId) {
-        if (Objects.nonNull(guestId)) {
+    public String removeCartItem(@CookieValue(value = "guestId", required = false) Long guestId,
+                                 @CookieValue(value = "access_token", required = false) String accessToken,
+                                 @PathVariable(name = "book-id") Long bookId) {
+        if (Objects.nonNull(guestId) || Objects.nonNull(accessToken)) {
             orderApiClient.removeProductFromCart(guestId, bookId);
         }
         return "redirect:/user/main-cart";

--- a/src/main/java/shop/wannab/frontservice/order/dto/UserAddressResponse.java
+++ b/src/main/java/shop/wannab/frontservice/order/dto/UserAddressResponse.java
@@ -10,4 +10,9 @@ public class UserAddressResponse {
     private String addressName;
     private String address;
     private String detailAddress;
+
+    @Override
+    public String toString() {
+        return String.format("[%s] %s %s", addressName, address, detailAddress);
+    }
 }

--- a/src/main/resources/static/js/main-order.js
+++ b/src/main/resources/static/js/main-order.js
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  // 포장지 변경 이벤트
+  // ✅ 포장지 선택 이벤트
   document.querySelectorAll('select[data-index]').forEach(selectEl => {
     selectEl.addEventListener('change', function () {
       const selectedOption = this.options[this.selectedIndex];
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
-  // 포인트 입력
+  // ✅ 포인트 사용 입력
   if (usedPointsInput) {
     usedPointsInput.addEventListener("input", function () {
       let usedPoints = parseInt(this.value, 10);
@@ -98,7 +98,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
-  // 쿠폰 선택 이벤트
+  // ✅ 쿠폰 선택 이벤트
   if (orderCouponSelect) {
     orderCouponSelect.addEventListener("change", () => {
       updateCouponDiscountDisplay();
@@ -113,12 +113,35 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
-  // 초기 렌더링 시 업데이트
+  // ✅ 배송지 select + hidden 연동
+  const addressSelect = document.getElementById("addressSelect");
+  const recipientAddressHidden = document.getElementById("recipientAddressHidden");
+  const manualAddressInput = document.getElementById("manualAddressInput");
+
+  if (addressSelect && recipientAddressHidden && manualAddressInput) {
+    addressSelect.addEventListener("change", function () {
+      const selectedValue = this.value;
+      if (selectedValue === "") {
+        // 직접 입력 모드
+        manualAddressInput.style.display = "inline";
+        recipientAddressHidden.value = "";
+        manualAddressInput.addEventListener("input", function () {
+          recipientAddressHidden.value = this.value;
+        });
+      } else {
+        // 저장된 주소 선택
+        manualAddressInput.style.display = "none";
+        recipientAddressHidden.value = selectedValue;
+      }
+    });
+  }
+
+  // ✅ 초기 렌더링 시 계산
   updateWrappingPriceDisplay();
   updateCouponDiscountDisplay();
   updateFinalAmount();
 
-  // 결제 버튼 클릭
+  // ✅ 결제 버튼 클릭
   paymentButton?.addEventListener('click', function () {
     const formData = new FormData(orderForm);
     const xhr = new XMLHttpRequest();
@@ -165,4 +188,3 @@ document.addEventListener('DOMContentLoaded', function () {
     xhr.send(formData);
   });
 });
-

--- a/src/main/resources/templates/user/main-order.html
+++ b/src/main/resources/templates/user/main-order.html
@@ -125,9 +125,32 @@
             </fieldset>
 
             <fieldset class="delivery-info-box">
-             <legend>배송지 정보</legend>
-             <input type="text" name="recipientAddress" placeholder="주소를 입력해주세요" required />
-           </fieldset>
+              <legend>배송지 정보</legend>
+
+              <input type="hidden" name="recipientAddress" id="recipientAddressHidden" required />
+
+               <!-- 회원 주소 선택 -->
+              <div th:if="${userId > 0}">
+                <label for="addressSelect">주소 선택</label>
+                <select id="addressSelect">
+                  <option value="">직접 입력</option>
+                  <option th:each="addr : ${userAddressList}"
+                          th:value="${addr.address + ' ' + addr.detailAddress}"
+                          th:attr="data-full-address=${addr.address + ' ' + addr.detailAddress}"
+                          th:text="'[' + ${addr.addressName} + '] ' + ${addr.address} + ' ' + ${addr.detailAddress}">
+                  </option>
+                </select>
+              </div>
+
+              <!-- 직접입력 input -->
+              <input type="text" id="manualAddressInput" placeholder="주소를 입력해주세요" style="display:none;" />
+
+              <!--비회원 주소 입력-->
+              <div th:if="${userId < 0}">
+                <input type="text" name="recipientAddress" placeholder="주소를 입력해주세요" required />
+              </div>
+            </fieldset>
+
           </div>
 
           <!-- 비회원일 경우 -->
@@ -174,5 +197,6 @@
 <script src="https://js.tosspayments.com/v2/standard"></script>
 
 <script th:src="@{/js/main-order.js}"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?
 
회원의 경우 마이페이지에서 등록한 주소들을 셀렉트박스로 보고, 선택할 수 있습니다.
비회원의 경우 주소를 직접입력합니다.
직접입력으로 등록한 주소 외 주소를 주문에 사용할 수 있습니다.

## 🔎 작업 상세 내용

- [x] 회원의 경우 주문시, 자신이 등록한 주소를 선택 가능하도록
- [x] 주소가 사용자에게 보였을때, 어색하지 않도록 toString overriding
- [x] guestId쿠키관련 회원 장바구니 로직 버그 수정
      
## ⏰ Pull Request 마감시간
> 7.9.18h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #117 
Closes #103
