### PR TITLE
169/fix: 비회원 바로구매 버그 수정

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/controller/CartController.java
+++ b/src/main/java/shop/wannab/frontservice/order/controller/CartController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import shop.wannab.frontservice.order.client.OrderApiClient;
 import shop.wannab.frontservice.order.dto.GuestCartCookieDto;
 import shop.wannab.frontservice.order.dto.OrderBookInfoListDto;
-import shop.wannab.frontservice.order.service.CartService;
+import shop.wannab.frontservice.order.service.CartOrderService;
 
 @Slf4j
 @Controller
@@ -26,7 +26,7 @@ import shop.wannab.frontservice.order.service.CartService;
 @RequiredArgsConstructor
 public class CartController {
     private final OrderApiClient orderApiClient;
-    private final CartService cartService;
+    private final CartOrderService cartOrderService;
 
     @GetMapping
     public String getCartPage(@CookieValue(value = "guestId", required = false) Long guestId, @CookieValue(value = "access_token", required = false) String accessToken, Model model) {
@@ -46,7 +46,7 @@ public class CartController {
                                 @RequestParam Long bookId, HttpServletResponse response) {
         if (Objects.isNull(guestId) && Objects.isNull(accessToken)) {//비회원 && 장바구니에 처음 상품 담을시
             GuestCartCookieDto guestCartCookieDto = orderApiClient.createCart();
-            cartService.setGuestCookie(guestCartCookieDto, response);
+            cartOrderService.setGuestCookie(guestCartCookieDto, response);
             guestId = guestCartCookieDto.getValue();
         }
         orderApiClient.addProductToCart(guestId, bookId);

--- a/src/main/java/shop/wannab/frontservice/order/controller/OrderController.java
+++ b/src/main/java/shop/wannab/frontservice/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package shop.wannab.frontservice.order.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,13 +12,12 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import shop.wannab.frontservice.order.client.OrderApiClient;
-import shop.wannab.frontservice.order.dto.OrderInfoForPayment;
-import shop.wannab.frontservice.order.dto.OrderItemListDto;
-import shop.wannab.frontservice.order.dto.OrderPageRequestDto;
-import shop.wannab.frontservice.order.dto.OrderSubmitDto;
+import shop.wannab.frontservice.order.dto.*;
 import shop.wannab.frontservice.order.exception.OrderItemValidationError;
+import shop.wannab.frontservice.order.service.CartOrderService;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Controller
@@ -25,13 +25,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderController {
     private final OrderApiClient orderApiClient;
-
+    private final CartOrderService cartOrderService;
     @Value("${toss.payments.clientKey}")
     private String clientKey;
 
     @PostMapping("/user/main-order")
-    public String getOrderItems(@CookieValue(value = "guestId", required = false) Long guestId, @ModelAttribute OrderItemListDto orderItemListDto) {
+    public String getOrderItems(@CookieValue(value = "guestId", required = false) Long guestId,
+                                @CookieValue(value = "access_token", required = false) String accessToken,
+                                @ModelAttribute OrderItemListDto orderItemListDto,
+                                HttpServletResponse response) {
 
+        if (Objects.isNull(guestId) && Objects.isNull(accessToken)) {//비회원 && 장바구니에 처음 상품 담을시
+            GuestCartCookieDto guestCartCookieDto = orderApiClient.createCart();
+            cartOrderService.setGuestCookie(guestCartCookieDto, response);
+            guestId = guestCartCookieDto.getValue();
+        }
         if (orderItemListDto.getOrderItems().size() == 0) {
             log.debug("OrderController : GetOrderItems : orderItemListDto.getOrderItems().size() == 0");
             return "redirect:/user/main-cart";

--- a/src/main/java/shop/wannab/frontservice/order/service/CartOrderService.java
+++ b/src/main/java/shop/wannab/frontservice/order/service/CartOrderService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import shop.wannab.frontservice.order.dto.GuestCartCookieDto;
 
 @Service
-public class CartService {
+public class CartOrderService {
     public void setGuestCookie(GuestCartCookieDto guestCartCookieDto, HttpServletResponse response) {
         Cookie cookie = new Cookie(guestCartCookieDto.getKeyName(), String.valueOf(guestCartCookieDto.getValue()));
         cookie.setPath("/");


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?
기존: 비회원일시 장바구니에 한번은 상품을 넣고난 후 바로구매 할수 있었음

쿠키에 guestId가 없을때 비회원 바로구매 기능이 작동하지 않던 것을 수정

## 🔎 작업 상세 내용

- [x] 비회원이면서 쿠키에 guestId가 없을경우, 바로구매 버튼 누를시, guestId생성
      
## ⏰ Pull Request 마감시간
> 7.14.16h

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #169 
