### PR TITLE
issue-172/fix : 회원주문목록 썸네일 추가

### DIFF
--- a/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderLookupResponse.java
+++ b/src/main/java/shop/wannab/frontservice/order/list/ordersManagement/dto/OrderLookupResponse.java
@@ -2,6 +2,7 @@ package shop.wannab.frontservice.order.list.ordersManagement.dto;
 
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 
 /**
@@ -9,6 +10,7 @@ import lombok.Data;
  * (현재 페이지에서는 도서정보도 포함)
  */
 @Data
+@NoArgsConstructor
 public class OrderLookupResponse {
     private Long orderId;
 
@@ -31,4 +33,6 @@ public class OrderLookupResponse {
      */
     private LocalDateTime shippedAt;
     private int totalPrice;
+
+    private String thumbnailUrl;
 }

--- a/src/main/resources/templates/user/mypage-order.html
+++ b/src/main/resources/templates/user/mypage-order.html
@@ -26,7 +26,7 @@
 
     <div th:each="order : ${orders}" class="order-card">
       <div class="order-product">
-        <img th:src="@{/static_images/testbook.png}" alt="book cover" />
+        <img th:src="${order.thumbnailUrl}" alt="book cover" />
         <div class="order-info">
           <small th:text="${#temporals.format(order.orderAt, 'yyyy-MM-dd HH:mm')}">주문일시</small>
           <strong th:text="'[주문번호] ' + ${order.orderId}"></strong><br />
@@ -43,7 +43,10 @@
         </div>
       </div>
       <div class="order-meta">
-        <p th:text="'출고일 : ' + ${#temporals.format(order.shippedAt, 'yyyy-MM-dd HH:mm')}"></p>
+        <p th:if="${order.shippedAt != null}"
+           th:text="'출고일 : ' + ${#temporals.format(order.shippedAt, 'yyyy-MM-dd HH:mm')}"></p>
+        <p th:unless="${order.shippedAt != null}"
+           th:text="'출고일 : 출고대기중'"></p>
         <p>
           <a th:href="@{/user/mypage-order-detail(orderId=${order.orderId})}" class="detail">상세 보기</a>
           <span class="return text-xs text-yellow-600 cursor-pointer"


### PR DESCRIPTION

## 🥳 어떤 기능을 구현했나요?

> 회원주문목록 하드코딩된 썸네일이미지를 주문한 도서 썸네일로 변경 (여러개 시켰을경우 첫번째에 장바구니에 넣은 도서의 이미지를 띄움)

## 🔎 작업 상세 내용

- [x] DTO에 썸네일 필드추가에 따른 html 일부 수정
      
## ⏰ Pull Request 마감시간
> 7/15 10:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #172 