### PR TITLE
fix: oauth2 배포환경 세션 문제 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
 		<version>3.3.12</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
+
 	<groupId>shop.wannab</groupId>
 	<artifactId>frontservice</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -133,8 +134,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-data-redis</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.minio</groupId>

--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -46,6 +46,12 @@ spring:
             token-uri: https://id.payco.com/oauth2.0/token
             user-info-uri: https://apis-payco.krp.toastoven.net/payco/friends/find_member_v2.json
             user-name-attribute: idNo
+  data:
+    redis:
+      host: 11.111.11.11
+      port: 6666
+      password: ci-secret
+      database: 123
 eureka:
   client:
     enabled: false


### PR DESCRIPTION

-  <180/oauth2 환경 수정> 

## 🥳 어떤 기능을 구현했나요?

> oauth2의 세션 문제 해결

## 🔎 작업 상세 내용

- [x] 스프링 시큐리티가 세션을 레디스에 저장하도록 설정 수정
      
## ⏰ Pull Request 마감시간
> 13:00

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #180
